### PR TITLE
Add lazy loading to images

### DIFF
--- a/_posts/2016-06-22-ocaml-raspberry-pi.md
+++ b/_posts/2016-06-22-ocaml-raspberry-pi.md
@@ -35,7 +35,7 @@ sudo apt-get install ocaml
 The installation takes a few minutes but after that, we can use OCaml without
 problem.
 
-<a href="http://blog.danny-willems.be/wp-content/uploads/2016/06/Selection_003.png" rel="attachment wp-att-287"><img src="http://blog.danny-willems.be/wp-content/uploads/2016/06/Selection_003.png" alt="OCaml on Raspberry Pi" width="553" height="110" class="size-full wp-image-287" /></a>
+<a href="http://blog.danny-willems.be/wp-content/uploads/2016/06/Selection_003.png" rel="attachment wp-att-287"><img src="http://blog.danny-willems.be/wp-content/uploads/2016/06/Selection_003.png" alt="OCaml on Raspberry Pi" width="553" height="110" class="size-full wp-image-287" loading="lazy" /></a>
 
 ## Clone, compile and install OPAM
 
@@ -89,12 +89,12 @@ It takes a very long time because the Raspberry Pi needs to compile OCaml. CPU
 is always at 100% but it doesn't take too much RAM, the entire system taking 200
 MB max. You will be stuck at this step for a long time.
 
-<a href="http://blog.danny-willems.be/wp-content/uploads/2016/06/Selection_004.png" rel="attachment wp-att-293"><img src="http://blog.danny-willems.be/wp-content/uploads/2016/06/Selection_004.png" alt="OPAM switch 4.03.0 stuck" width="651" height="154" class="size-full wp-image-293" /></a>
+<a href="http://blog.danny-willems.be/wp-content/uploads/2016/06/Selection_004.png" rel="attachment wp-att-293"><img src="http://blog.danny-willems.be/wp-content/uploads/2016/06/Selection_004.png" alt="OPAM switch 4.03.0 stuck" width="651" height="154" class="size-full wp-image-293" loading="lazy" /></a>
 
 And after around 1 hour, we have an fresh OCaml 4.03.0 installation on our
 Raspberry Pi:
 
-<a href="http://blog.danny-willems.be/wp-content/uploads/2016/06/Selection_001.png" rel="attachment wp-att-295"><img src="http://blog.danny-willems.be/wp-content/uploads/2016/06/Selection_001.png" alt="ocaml 4.03.0" width="308" height="64" class="size-full wp-image-295" /></a>
+<a href="http://blog.danny-willems.be/wp-content/uploads/2016/06/Selection_001.png" rel="attachment wp-att-295"><img src="http://blog.danny-willems.be/wp-content/uploads/2016/06/Selection_001.png" alt="ocaml 4.03.0" width="308" height="64" class="size-full wp-image-295" loading="lazy" /></a>
 
 ## Install an OPAM package: js_of_ocaml
 

--- a/_posts/2016-07-14-ocaml-cordova-secured-typed-hybrid-mobile-applications.md
+++ b/_posts/2016-07-14-ocaml-cordova-secured-typed-hybrid-mobile-applications.md
@@ -173,15 +173,15 @@ code in
 <a href="https://github.com/dannywillems/ocaml-cordova-plugin-sms-example">this
 repository</a>
 
-<a href="http://blog.danny-willems.be/wp-content/uploads/2016/07/Selection_002.png"><img src="http://blog.danny-willems.be/wp-content/uploads/2016/07/Selection_002-170x300.png" alt="ocaml-cordova-plugin-sms-example" width="170" height="300" class="size-medium wp-image-410"></a>
+<a href="http://blog.danny-willems.be/wp-content/uploads/2016/07/Selection_002.png"><img src="http://blog.danny-willems.be/wp-content/uploads/2016/07/Selection_002-170x300.png" alt="ocaml-cordova-plugin-sms-example" width="170" height="300" class="size-medium wp-image-410" loading="lazy"></a>
 
 Other examples can be found
 <a href="https://github.com/dannywillems/ocaml-cordova-plugin-list">here</a>.
 Here some other screenshots.
 
-<a href="http://blog.danny-willems.be/wp-content/uploads/2016/07/screenshot_android.png"><img src="http://blog.danny-willems.be/wp-content/uploads/2016/07/screenshot_android-167x300.png" alt="ocaml-cordova-plugin-toast-example-android" width="167" height="300" class="size-medium wp-image-415"></a>
+<a href="http://blog.danny-willems.be/wp-content/uploads/2016/07/screenshot_android.png"><img src="http://blog.danny-willems.be/wp-content/uploads/2016/07/screenshot_android-167x300.png" alt="ocaml-cordova-plugin-toast-example-android" width="167" height="300" class="size-medium wp-image-415" loading="lazy"></a>
 
-<a href="http://blog.danny-willems.be/wp-content/uploads/2016/07/screenshot_ios.png"><img src="http://blog.danny-willems.be/wp-content/uploads/2016/07/screenshot_ios-166x300.png" alt="ocaml-cordova-plugin-toast-example-ios" width="166" height="300" class="size-medium wp-image-414"></a>
+<a href="http://blog.danny-willems.be/wp-content/uploads/2016/07/screenshot_ios.png"><img src="http://blog.danny-willems.be/wp-content/uploads/2016/07/screenshot_ios-166x300.png" alt="ocaml-cordova-plugin-toast-example-ios" width="166" height="300" class="size-medium wp-image-414" loading="lazy"></a>
 
 ### Set up the development environment
 

--- a/index.md
+++ b/index.md
@@ -1,7 +1,7 @@
 <div class="row">
   <div class="col-6">
     <div class="center">
-        <img class="portrait" src="{{ 'assets/me.jpg'}}" />
+        <img class="portrait" src="{{ 'assets/me.jpg'}}" alt="Danny Willems portrait" loading="lazy" />
     </div>
     <p class="center">
       Currently:
@@ -23,21 +23,21 @@
     </p>
     <div class="center">
        <a href="https://twitter.com/dwillems42" class="logo-link">
-         <img class="logo" src="{{ 'assets/twitter.svg' }}">
+         <img class="logo" src="{{ 'assets/twitter.svg' }}" alt="Twitter">
        </a>
        <a href="https://github.com/dannywillems" class="logo-link">
-         <img class="logo" src="{{ 'assets/github.svg' }}" >
+         <img class="logo" src="{{ 'assets/github.svg' }}" alt="GitHub">
        </a>
        <a href="https://gitlab.com/dannywillems" class="logo-link">
-         <img class="logo" src="{{ 'assets/gitlab.svg' }}" >
+         <img class="logo" src="{{ 'assets/gitlab.svg' }}" alt="GitLab">
        </a>
        <a href="https://linkedin.com/in/bedannywillems" class="logo-link">
-         <img class="logo" src="{{ 'assets/linkedin.svg' }}">
+         <img class="logo" src="{{ 'assets/linkedin.svg' }}" alt="LinkedIn">
        </a>
     </div>
     <div class="center">
        <a href="https://leakix.net" class="logo-link">
-         <img class="logo" src="{{ 'assets/leakix.svg' }}">
+         <img class="logo" src="{{ 'assets/leakix.svg' }}" alt="LeakIX">
        </a>
        <a href='http://www.catb.org/hacker-emblem/'>
          <img src="{{ 'assets/Glider.svg' }}" alt='hacker emblem' class="logo" />


### PR DESCRIPTION
## Summary
- Add `loading="lazy"` attribute to portrait image and blog post images
- Add alt attributes to social media icons for accessibility

## Changes
- `index.md`: Portrait image + social icons alt text
- `_posts/2016-06-22-ocaml-raspberry-pi.md`: 3 images
- `_posts/2016-07-14-ocaml-cordova-secured-typed-hybrid-mobile-applications.md`: 3 images

Closes #34

## Test plan
- [ ] Verify images load lazily (check network tab in devtools)
- [ ] Verify alt text appears on hover/screen readers