### PR TITLE
Remove unused Google Analytics code

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -78,17 +78,6 @@
         {{ content }}
       </section>
     </div>
-
-    {% if site.google_analytics %}
-      <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-        ga('create', '{{ site.google_analytics }}', 'auto');
-        ga('send', 'pageview');
-      </script>
-    {% endif %}
   </body>
 </html>
 


### PR DESCRIPTION
## Summary
- Remove unused Google Analytics code from `_layouts/default.html`
- The GA tracking ID was never configured, so the code was dead weight

Closes #37

## Test plan
- [ ] Verify site builds correctly
- [ ] Verify no GA script in page source