### PR TITLE
Fix: Add bottom padding to website

### DIFF
--- a/assets/custom.css
+++ b/assets/custom.css
@@ -39,6 +39,7 @@ body {
   width: 90%;
   margin-left: auto;
   margin-right: auto;
+  padding-bottom: 3rem;
 }
 
 .row {


### PR DESCRIPTION
## Summary

Add 3rem bottom padding to the `.container` class to provide proper spacing at the bottom of the website.

## Test plan

- [ ] Verify bottom of page has adequate spacing
- [ ] Check on mobile and desktop viewports

Closes #50