### PR TITLE
Add Resume link to header navigation

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -38,6 +38,9 @@
               {{ site.description | default: site.github.project_tagline }}
           </h2>
         <div>
+          <a href="/cv/" class="btn">
+              Resume (PDF)
+          </a>
           <a href="/contributions/" class="btn">
               Contributions
           </a>


### PR DESCRIPTION
## Summary
- Add prominent "Resume (PDF)" link as first item in header navigation
- Makes it easy for recruiters to find and download the resume

## Test plan
- [ ] Verify "Resume (PDF)" button appears first in header
- [ ] Verify clicking it goes to /cv/ page with print functionality