### PR TITLE
Center profile section vertically with bio text

### DIFF
--- a/assets/custom.css
+++ b/assets/custom.css
@@ -576,3 +576,21 @@ body {
     display: none;
   }
 }
+
+/* === PROFILE SECTION === */
+@media only screen and (min-width: 45em) {
+  .profile-row {
+    display: flex;
+    align-items: center;
+  }
+
+  .profile-row .col-6 {
+    float: none;
+  }
+
+  .profile-left {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+  }
+}

--- a/index.md
+++ b/index.md
@@ -1,5 +1,5 @@
-<div class="row">
-  <div class="col-6">
+<div class="row profile-row">
+  <div class="col-6 profile-left">
     <div class="center">
         <img class="portrait" src="{{ 'assets/me.jpg'}}" alt="Danny Willems portrait" loading="lazy" />
     </div>


### PR DESCRIPTION
## Summary
- Use flexbox for the profile row on larger screens
- Center the left column (picture, socials, Currently) vertically
- Aligns with the middle of the bio text on the right

Closes #65

## Test plan
- [ ] On desktop, verify profile picture and socials are vertically centered with the bio text
- [ ] On mobile, verify layout still stacks correctly