### PR TITLE
chore: add Claude Code GitHub Action workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,35 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && contains(github.event.issue.body, '@claude'))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run Claude Code
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_args: "--max-turns 10"


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow for Claude Code @claude mentions
- Enables AI assistance in issues and PRs

## Setup Required
After merging, add `ANTHROPIC_API_KEY` to repository secrets:
1. Go to Settings > Secrets and variables > Actions
2. Add new repository secret named `ANTHROPIC_API_KEY`
3. Paste your Anthropic API key

## Usage
Tag `@claude` in any issue or PR comment:
- `@claude review this PR`
- `@claude fix this bug`
- `@claude explain this code`

## Related
Part of #96 (Epic: Automated daily Claude Code feature articles)

## Test plan
- [ ] Merge PR and add API key
- [ ] Test @claude mention in an issue
- [ ] Verify Claude responds appropriately