### PR TITLE
feat: auto-retarget Dependabot PRs to develop

### DIFF
--- a/.github/scripts/retarget-pr.js
+++ b/.github/scripts/retarget-pr.js
@@ -1,0 +1,29 @@
+/**
+ * Retarget a PR from master to develop.
+ *
+ * This script is used by the retarget-dependabot.yml workflow.
+ *
+ * @param {Object} github - GitHub API client from actions/github-script
+ * @param {Object} context - GitHub Actions context
+ */
+module.exports = async ({ github, context }) => {
+  const prNumber = context.payload.pull_request.number;
+
+  console.log(`Retargeting PR #${prNumber} from master to develop`);
+
+  await github.rest.pulls.update({
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    pull_number: prNumber,
+    base: "develop",
+  });
+
+  await github.rest.issues.createComment({
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    issue_number: prNumber,
+    body: "Automatically retargeted this PR from `master` to `develop`.",
+  });
+
+  console.log(`PR #${prNumber} retargeted to develop`);
+};

--- a/.github/workflows/retarget-dependabot.yml
+++ b/.github/workflows/retarget-dependabot.yml
@@ -1,0 +1,23 @@
+name: Retarget Dependabot PRs
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  retarget:
+    if: github.actor == 'dependabot[bot]' && github.base_ref == 'master'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Change base branch to develop
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const script = require('./.github/scripts/retarget-pr.js');
+            await script({ github, context });


### PR DESCRIPTION
## Summary

Automatically retargets Dependabot PRs from `master` to `develop`.

When Dependabot opens a PR targeting `master`, this workflow:
1. Changes the base branch to `develop`
2. Adds a comment explaining the change

## Files

- `.github/workflows/retarget-dependabot.yml` - Workflow triggered on PR open
- `.github/scripts/retarget-pr.js` - Script to change base branch

Closes #125