### PR TITLE
feat: add multi-theme system with 5 themes

### DIFF
--- a/_includes/theme-switcher.html
+++ b/_includes/theme-switcher.html
@@ -1,0 +1,10 @@
+<div class="theme-switcher">
+  <label for="theme-select" class="theme-switcher-label">Theme:</label>
+  <select id="theme-select">
+    <option value="hacker">Hacker</option>
+    <option value="neon">Neon</option>
+    <option value="minimal">Minimal</option>
+    <option value="twilight">Twilight</option>
+    <option value="paper">Paper</option>
+  </select>
+</div>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,18 +1,29 @@
 <!DOCTYPE html>
-<html lang="{{ site.lang | default: "en-US" }}">
+<html lang="{{ site.lang | default: "en-US" }}" class="theme-hacker">
   <head>
     <meta charset='utf-8'>
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta property=’og:title’ content="{{ site.title }}" />
-    <meta property=’og:image’ content="{{ '/assets/me.jpg' }}"/>
-    <meta property=’og:description’ content='{{ site.description }}' />
-    <meta property=’og:url’ content='{{ site.url }}' />
+    <meta property='og:title' content="{{ site.title }}" />
+    <meta property='og:image' content="{{ '/assets/me.jpg' }}"/>
+    <meta property='og:description' content='{{ site.description }}' />
+    <meta property='og:url' content='{{ site.url }}' />
     <meta property='og:image:width' content='1200' />
     <meta property='og:image:height' content='1200' />
+
+    <!-- Theme initialization (prevents FOUC) -->
+    <script>
+      (function() {
+        var theme = localStorage.getItem('site-theme') || 'hacker';
+        var validThemes = ['hacker', 'neon', 'minimal', 'twilight', 'paper'];
+        if (validThemes.indexOf(theme) === -1) theme = 'hacker';
+        document.documentElement.className = 'theme-' + theme;
+      })();
+    </script>
+
     <link rel="stylesheet" href="{{ '/assets/css/style.css?v=' | append: site.github.build_revision | relative_url }}">
-    <link rel="stylesheet" href="{{ '/assets/custom.css' | relative_url }}">
-    
+    <link rel="stylesheet" href="{{ '/assets/css/main.css' | relative_url }}">
+
     <!-- Favicons -->
     <link rel="icon" type="image/x-icon" href="{{ '/favicon.ico' | relative_url }}">
     <link rel="icon" type="image/png" sizes="16x16" href="{{ '/favicon-16x16.png' | relative_url }}">
@@ -110,10 +121,11 @@
         </div>
         <div class="footer-bottom">
           <p>&copy; {{ 'now' | date: "%Y" }} Danny Willems</p>
+          {% include theme-switcher.html %}
         </div>
       </div>
     </footer>
+
+    <script src="{{ '/assets/js/theme-switcher.js' | relative_url }}"></script>
   </body>
 </html>
-
-

--- a/_sass/site/_base.scss
+++ b/_sass/site/_base.scss
@@ -1,0 +1,122 @@
+// =============================================================================
+// BASE STYLES
+// Only applies to non-hacker themes to preserve original design
+// =============================================================================
+
+// -----------------------------------------------------------------------------
+// Text Alignment Utilities (applies to all themes)
+// -----------------------------------------------------------------------------
+
+.left {
+  text-align: left;
+}
+
+.right {
+  text-align: right;
+}
+
+.center {
+  text-align: center;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.justify {
+  text-align: justify;
+}
+
+// -----------------------------------------------------------------------------
+// Non-Hacker Theme Base Styles
+// These override the default theme styles for alternative themes
+// -----------------------------------------------------------------------------
+
+html:not(.theme-hacker) {
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  transition: background $transition-slow, color $transition-slow;
+
+  body {
+    background: var(--bg-primary);
+    color: var(--text-primary);
+    font-family: $font-sans;
+  }
+
+  // Typography
+  h1, h2, h3, h4, h5, h6 {
+    color: var(--text-primary);
+    font-family: $font-sans;
+    font-weight: 600;
+    text-shadow: none;
+    letter-spacing: normal;
+  }
+
+  p, li {
+    color: var(--text-primary);
+  }
+
+  // Links
+  a {
+    color: var(--accent);
+    text-shadow: none;
+
+    &:hover {
+      color: var(--accent-hover);
+    }
+  }
+
+  // Code
+  code {
+    background: var(--bg-secondary);
+    color: var(--accent);
+    border: 1px solid var(--border);
+  }
+
+  code.highlighter-rouge {
+    background: var(--bg-secondary);
+    color: var(--accent);
+    border: 1px solid var(--border);
+  }
+
+  pre {
+    background: var(--bg-secondary);
+    border: 1px solid var(--border);
+
+    code {
+      background: transparent;
+      border: none;
+    }
+  }
+
+  // Tables
+  th {
+    color: var(--accent);
+    border-bottom: 1px solid var(--accent);
+  }
+
+  td {
+    border-bottom: 1px solid var(--border);
+  }
+
+  // Blockquote
+  blockquote {
+    border-left-color: var(--accent);
+    color: var(--text-secondary);
+  }
+
+  // Horizontal rule
+  hr {
+    border-bottom-color: var(--accent);
+  }
+
+  // Selection
+  ::selection {
+    background: var(--accent);
+    color: var(--bg-primary);
+  }
+
+  // List bullets - remove custom image for non-hacker themes
+  ul li {
+    list-style-image: none;
+    list-style-type: disc;
+  }
+}

--- a/_sass/site/_components.scss
+++ b/_sass/site/_components.scss
@@ -1,0 +1,925 @@
+// =============================================================================
+// COMPONENT STYLES
+// Reusable UI components - preserves original hacker theme styles
+// =============================================================================
+
+// -----------------------------------------------------------------------------
+// Portrait (applies to all themes)
+// -----------------------------------------------------------------------------
+
+.portrait {
+  width: 250px;
+  height: 250px;
+  border-radius: $radius-full;
+}
+
+// -----------------------------------------------------------------------------
+// Logo (applies to all themes)
+// -----------------------------------------------------------------------------
+
+.logo-link {
+  text-decoration: none;
+}
+
+.logo {
+  width: 48px;
+  height: 48px;
+}
+
+.icon {
+  height: 40px;
+  width: 40px;
+}
+
+// -----------------------------------------------------------------------------
+// Publications (applies to all themes - uses hardcoded colors for hacker)
+// -----------------------------------------------------------------------------
+
+.publications {
+  margin-bottom: $spacing-md;
+}
+
+.publication-year {
+  font-weight: bold;
+  font-size: 20px;
+}
+
+.publication-title {
+  font-weight: bold;
+}
+
+.publication-description {
+  padding-left: 15px;
+}
+
+.publication-authors {
+  padding-left: 15px;
+  font-size: $font-size-xs;
+}
+
+.publication-item {
+  padding-left: 10px;
+}
+
+.publication-links {
+  margin-left: 15px;
+}
+
+.publication-link {
+  display: inline-block;
+  font-weight: 400;
+  line-height: 1.5;
+  color: #b5e853;
+  text-align: center;
+  text-decoration: none;
+  vertical-align: middle;
+  cursor: pointer;
+  user-select: none;
+  background-color: transparent;
+  border: 1px solid #b5e853;
+  padding: $spacing-sm $spacing-md;
+  font-size: $font-size-base;
+  border-radius: $radius-sm;
+  transition: color $transition-fast, background-color $transition-fast, border-color $transition-fast;
+  padding-left: 10px;
+
+  &:hover {
+    color: #1a1a1a;
+    background-color: #b5e853;
+    border-color: #b5e853;
+    text-decoration: none;
+  }
+
+  &:active {
+    color: #1a1a1a;
+    background-color: #9ccc3d;
+    border-color: #9ccc3d;
+  }
+}
+
+// Non-hacker theme publication links
+html:not(.theme-hacker) .publication-link {
+  color: var(--accent);
+  border-color: var(--accent);
+
+  &:hover {
+    color: var(--bg-primary);
+    background-color: var(--accent);
+    border-color: var(--accent);
+  }
+
+  &:active {
+    color: var(--bg-primary);
+    background-color: var(--accent-hover);
+    border-color: var(--accent-hover);
+  }
+}
+
+// -----------------------------------------------------------------------------
+// CV / Employment (applies to all themes - uses hardcoded colors for hacker)
+// -----------------------------------------------------------------------------
+
+.cv-jobs {
+  margin-bottom: $spacing-xl;
+}
+
+.cv-job {
+  margin-bottom: $spacing-lg;
+  padding-left: $spacing-md;
+  border-left: 2px solid #444;
+}
+
+.cv-employer {
+  font-size: $font-size-lg;
+  font-weight: bold;
+  margin-bottom: $spacing-sm;
+
+  a {
+    color: #b5e853;
+    text-decoration: none;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+}
+
+.cv-positions {
+  margin-bottom: $spacing-sm;
+}
+
+.cv-position {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: $spacing-sm;
+
+  @media only screen and (max-width: $breakpoint-md) {
+    flex-direction: column;
+    gap: $spacing-xs;
+  }
+}
+
+.cv-position-multi {
+  padding-left: $spacing-md;
+  border-left: 1px solid #666;
+  margin-bottom: $spacing-xs;
+}
+
+.cv-title {
+  font-weight: 500;
+}
+
+.cv-dates {
+  font-size: $font-size-sm;
+  color: #888;
+
+  @media only screen and (max-width: $breakpoint-md) {
+    font-size: $font-size-sm;
+  }
+}
+
+.cv-description {
+  font-size: 0.95rem;
+  margin-top: $spacing-sm;
+  color: #ccc;
+
+  p {
+    margin: $spacing-xs 0;
+  }
+}
+
+.cv-links {
+  margin-top: $spacing-sm;
+}
+
+// Non-hacker theme CV overrides
+html:not(.theme-hacker) {
+  .cv-job {
+    border-left-color: var(--border-light);
+  }
+
+  .cv-employer a {
+    color: var(--accent);
+  }
+
+  .cv-position-multi {
+    border-left-color: var(--text-tertiary);
+  }
+
+  .cv-dates {
+    color: var(--text-secondary);
+  }
+
+  .cv-description {
+    color: var(--text-primary);
+  }
+}
+
+// -----------------------------------------------------------------------------
+// CV / Education
+// -----------------------------------------------------------------------------
+
+.cv-education {
+  margin-bottom: $spacing-xl;
+}
+
+.cv-edu {
+  margin-bottom: $spacing-lg;
+  padding-left: $spacing-md;
+  border-left: 2px solid #444;
+}
+
+.cv-institution {
+  font-size: $font-size-lg;
+  font-weight: bold;
+  margin-bottom: $spacing-sm;
+
+  a {
+    color: #b5e853;
+    text-decoration: none;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+}
+
+.cv-degree {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: $spacing-sm;
+  margin-bottom: $spacing-sm;
+
+  @media only screen and (max-width: $breakpoint-md) {
+    flex-direction: column;
+    gap: $spacing-xs;
+  }
+}
+
+// Non-hacker theme education overrides
+html:not(.theme-hacker) {
+  .cv-edu {
+    border-left-color: var(--border-light);
+  }
+
+  .cv-institution a {
+    color: var(--accent);
+  }
+}
+
+// -----------------------------------------------------------------------------
+// Footer (applies to all themes - uses hardcoded colors for hacker)
+// -----------------------------------------------------------------------------
+
+.site-footer {
+  background-color: #1a1a1a;
+  border-top: 1px solid #333;
+  padding: $spacing-xl 0 $spacing-md;
+  margin-top: $spacing-2xl;
+
+  .container {
+    padding-bottom: 0;
+  }
+
+  h3 {
+    font-size: $font-size-sm;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    margin-bottom: $spacing-sm;
+    color: #b5e853;
+  }
+
+  a {
+    color: #ccc;
+    display: block;
+    margin-bottom: $spacing-sm;
+
+    &:hover {
+      color: #b5e853;
+      text-decoration: none;
+    }
+  }
+}
+
+.footer-content {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: $spacing-xl;
+  margin-bottom: $spacing-xl;
+
+  @media only screen and (max-width: $breakpoint-md) {
+    flex-direction: column;
+    gap: $spacing-lg;
+  }
+}
+
+.footer-contact,
+.footer-social,
+.footer-quick {
+  flex: 1;
+  min-width: 150px;
+}
+
+.footer-social-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: $spacing-sm $spacing-md;
+
+  a {
+    display: inline;
+  }
+}
+
+.footer-bottom {
+  border-top: 1px solid #333;
+  padding-top: $spacing-md;
+  text-align: center;
+
+  p {
+    color: #666;
+    font-size: $font-size-sm;
+    margin: 0;
+  }
+}
+
+// -----------------------------------------------------------------------------
+// GitHub Contributions
+// -----------------------------------------------------------------------------
+
+.contributions {
+  margin-bottom: $spacing-xl;
+}
+
+.contributions-updated {
+  font-size: $font-size-sm;
+  color: #666;
+  margin-bottom: $spacing-lg;
+}
+
+.contributions-summary h3,
+.contributions-repos h3 {
+  color: #b5e853;
+  margin-bottom: $spacing-md;
+  font-size: 1.1rem;
+}
+
+.contributions-totals {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: $spacing-md;
+  margin-bottom: $spacing-xl;
+}
+
+.contributions-period {
+  background: #1a1a1a;
+  border: 1px solid #333;
+  border-radius: $radius-md;
+  padding: $spacing-md;
+
+  h4 {
+    margin: 0 0 $spacing-sm 0;
+    font-size: $font-size-sm;
+    color: #ccc;
+  }
+}
+
+.contributions-stats {
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-xs;
+
+  .stat {
+    font-size: $font-size-sm;
+    color: #888;
+
+    strong {
+      color: #b5e853;
+      font-size: 1.1rem;
+    }
+  }
+}
+
+.contributions-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: $font-size-sm;
+
+  th, td {
+    padding: $spacing-sm;
+    text-align: left;
+    border-bottom: 1px solid #333;
+  }
+
+  th {
+    color: #b5e853;
+    font-weight: 600;
+    font-size: $font-size-sm;
+  }
+
+  .repo-name a {
+    color: #ccc;
+
+    &:hover {
+      color: #b5e853;
+    }
+  }
+
+  .repo-stat {
+    text-align: center;
+
+    .total {
+      display: block;
+      font-weight: 600;
+      color: #eee;
+    }
+
+    .breakdown {
+      display: block;
+      font-size: $font-size-xs;
+      color: #666;
+    }
+
+    .zero {
+      color: #444;
+    }
+  }
+
+  @media only screen and (max-width: $breakpoint-md) {
+    font-size: 0.8rem;
+
+    th, td {
+      padding: 0.35rem;
+    }
+
+    .repo-stat .breakdown {
+      display: none;
+    }
+  }
+}
+
+.contributions-note {
+  margin-top: $spacing-lg;
+  font-size: $font-size-sm;
+  color: #666;
+}
+
+// Non-hacker theme contributions overrides
+html:not(.theme-hacker) {
+  .contributions-updated {
+    color: var(--text-tertiary);
+  }
+
+  .contributions-summary h3,
+  .contributions-repos h3 {
+    color: var(--accent);
+  }
+
+  .contributions-period {
+    background: var(--bg-secondary);
+    border-color: var(--border);
+
+    h4 {
+      color: var(--text-primary);
+    }
+  }
+
+  .contributions-stats {
+    .stat {
+      color: var(--text-secondary);
+
+      strong {
+        color: var(--accent);
+      }
+    }
+  }
+
+  .contributions-table {
+    th, td {
+      border-bottom-color: var(--border);
+    }
+
+    th {
+      color: var(--accent);
+    }
+
+    .repo-name a {
+      color: var(--text-primary);
+
+      &:hover {
+        color: var(--accent);
+      }
+    }
+
+    .repo-stat {
+      .total {
+        color: var(--text-primary);
+      }
+
+      .breakdown {
+        color: var(--text-tertiary);
+      }
+
+      .zero {
+        color: var(--border-light);
+      }
+    }
+  }
+
+  .contributions-note {
+    color: var(--text-tertiary);
+  }
+}
+
+// -----------------------------------------------------------------------------
+// Countries
+// -----------------------------------------------------------------------------
+
+.countries {
+  margin-bottom: $spacing-xl;
+}
+
+.countries-stats {
+  display: flex;
+  gap: $spacing-xl;
+  margin-bottom: $spacing-xl;
+
+  @media only screen and (max-width: $breakpoint-md) {
+    flex-direction: column;
+    gap: $spacing-md;
+  }
+}
+
+.countries-stat {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: $spacing-md $spacing-xl;
+  background: #1a1a1a;
+  border: 1px solid #333;
+  border-radius: $radius-md;
+
+  .stat-number {
+    font-size: 2.5rem;
+    font-weight: bold;
+    color: #b5e853;
+  }
+
+  .stat-label {
+    font-size: $font-size-sm;
+    color: #888;
+  }
+
+  @media only screen and (max-width: $breakpoint-md) {
+    padding: $spacing-sm $spacing-md;
+  }
+}
+
+.countries-by-continent {
+  margin-top: $spacing-xl;
+}
+
+.countries-continent {
+  margin-bottom: $spacing-xl;
+
+  h3 {
+    color: #b5e853;
+    border-bottom: 1px solid #333;
+    padding-bottom: $spacing-sm;
+    margin-bottom: $spacing-md;
+  }
+}
+
+.countries-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+  gap: $spacing-md;
+
+  @media only screen and (max-width: $breakpoint-md) {
+    grid-template-columns: 1fr;
+  }
+}
+
+.country-card {
+  background: #1a1a1a;
+  border: 1px solid #333;
+  border-radius: $radius-md;
+  padding: $spacing-md;
+  transition: border-color $transition-fast;
+
+  &:hover {
+    border-color: #b5e853;
+  }
+
+  &.favorite {
+    border-left: 3px solid #b5e853;
+  }
+}
+
+.country-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  margin-bottom: $spacing-sm;
+}
+
+.country-name {
+  font-weight: 600;
+  color: #eee;
+}
+
+.country-year {
+  font-size: $font-size-sm;
+  color: #666;
+}
+
+.country-visits {
+  font-size: $font-size-sm;
+  color: #888;
+  margin-bottom: $spacing-xs;
+}
+
+.country-notes {
+  font-size: $font-size-sm;
+  color: #aaa;
+  font-style: italic;
+}
+
+// Non-hacker theme countries overrides
+html:not(.theme-hacker) {
+  .countries-stat {
+    background: var(--bg-secondary);
+    border-color: var(--border);
+
+    .stat-number {
+      color: var(--accent);
+    }
+
+    .stat-label {
+      color: var(--text-secondary);
+    }
+  }
+
+  .countries-continent h3 {
+    color: var(--accent);
+    border-bottom-color: var(--border);
+  }
+
+  .country-card {
+    background: var(--bg-secondary);
+    border-color: var(--border);
+
+    &:hover {
+      border-color: var(--accent);
+    }
+
+    &.favorite {
+      border-left-color: var(--accent);
+    }
+  }
+
+  .country-name {
+    color: var(--text-primary);
+  }
+
+  .country-year {
+    color: var(--text-tertiary);
+  }
+
+  .country-visits {
+    color: var(--text-secondary);
+  }
+
+  .country-notes {
+    color: var(--text-secondary);
+  }
+}
+
+// Countries Map
+.countries-map-container {
+  margin: $spacing-xl 0;
+}
+
+.countries-map {
+  position: relative;
+  background: #111;
+  border: 1px solid #333;
+  border-radius: $radius-md;
+  padding: $spacing-md;
+  overflow: hidden;
+
+  svg {
+    width: 100%;
+    height: auto;
+    display: block;
+  }
+
+  .city-overlay {
+    position: absolute;
+    top: $spacing-md;
+    left: $spacing-md;
+    right: $spacing-md;
+    bottom: $spacing-md;
+    pointer-events: none;
+  }
+}
+
+html:not(.theme-hacker) .countries-map {
+  background: var(--bg-tertiary);
+  border-color: var(--border);
+}
+
+.map-legend {
+  display: flex;
+  gap: $spacing-lg;
+  justify-content: center;
+  margin-top: $spacing-md;
+  font-size: $font-size-sm;
+  color: #888;
+}
+
+html:not(.theme-hacker) .map-legend {
+  color: var(--text-secondary);
+}
+
+.legend-visited,
+.legend-not-visited {
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  border-radius: 2px;
+  margin-right: $spacing-sm;
+  vertical-align: middle;
+}
+
+.legend-visited {
+  background: #b5e853;
+}
+
+html:not(.theme-hacker) .legend-visited {
+  background: var(--accent);
+}
+
+.legend-not-visited {
+  background: #333;
+}
+
+html:not(.theme-hacker) .legend-not-visited {
+  background: var(--border);
+}
+
+.legend-city {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  border-radius: $radius-full;
+  background: #ff6b6b;
+  margin-right: $spacing-sm;
+  vertical-align: middle;
+}
+
+// City markers on map
+.city-markers .city-marker {
+  circle {
+    fill: #ff6b6b;
+    stroke: #fff;
+    stroke-width: 1;
+  }
+
+  text {
+    fill: #fff;
+    font-size: 8px;
+    font-family: sans-serif;
+    pointer-events: none;
+  }
+}
+
+// -----------------------------------------------------------------------------
+// Cities
+// -----------------------------------------------------------------------------
+
+.cities {
+  margin-bottom: $spacing-xl;
+}
+
+.cities-stats {
+  display: flex;
+  gap: $spacing-xl;
+  margin-bottom: $spacing-xl;
+
+  @media only screen and (max-width: $breakpoint-md) {
+    flex-direction: column;
+    gap: $spacing-md;
+  }
+}
+
+.cities-stat {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: $spacing-md $spacing-xl;
+  background: #1a1a1a;
+  border: 1px solid #333;
+  border-radius: $radius-md;
+
+  .stat-number {
+    font-size: 2.5rem;
+    font-weight: bold;
+    color: #b5e853;
+  }
+
+  .stat-label {
+    font-size: $font-size-sm;
+    color: #888;
+  }
+}
+
+html:not(.theme-hacker) .cities-stat {
+  background: var(--bg-secondary);
+  border-color: var(--border);
+
+  .stat-number {
+    color: var(--accent);
+  }
+
+  .stat-label {
+    color: var(--text-secondary);
+  }
+}
+
+.cities-map-container {
+  height: 500px;
+  border: 1px solid #333;
+  border-radius: $radius-md;
+  margin-bottom: $spacing-xl;
+
+  @media only screen and (max-width: $breakpoint-md) {
+    height: 350px;
+  }
+}
+
+html:not(.theme-hacker) .cities-map-container {
+  border-color: var(--border);
+}
+
+.cities-list {
+  margin-top: $spacing-xl;
+
+  h3 {
+    color: #b5e853;
+    margin-bottom: $spacing-md;
+  }
+
+  ul {
+    list-style: none;
+    padding: 0;
+  }
+
+  li {
+    padding: $spacing-sm 0;
+    border-bottom: 1px solid #333;
+  }
+}
+
+html:not(.theme-hacker) .cities-list {
+  h3 {
+    color: var(--accent);
+  }
+
+  li {
+    border-bottom-color: var(--border);
+  }
+}
+
+.city-country {
+  color: #888;
+  font-size: $font-size-sm;
+}
+
+html:not(.theme-hacker) .city-country {
+  color: var(--text-secondary);
+}
+
+.city-date {
+  color: #666;
+  font-size: $font-size-sm;
+}
+
+html:not(.theme-hacker) .city-date {
+  color: var(--text-tertiary);
+}
+
+.city-notes {
+  color: #aaa;
+  font-size: $font-size-sm;
+  font-style: italic;
+  margin: $spacing-xs 0 0 0;
+}
+
+html:not(.theme-hacker) .city-notes {
+  color: var(--text-secondary);
+}

--- a/_sass/site/_layout.scss
+++ b/_sass/site/_layout.scss
@@ -1,0 +1,221 @@
+// =============================================================================
+// LAYOUT STYLES
+// Grid system, containers, header, and footer
+// =============================================================================
+
+// -----------------------------------------------------------------------------
+// Grid System (from simple-grid) - applies to all themes
+// -----------------------------------------------------------------------------
+
+.container {
+  width: 90%;
+  margin-left: auto;
+  margin-right: auto;
+  padding-bottom: $spacing-2xl;
+
+  @media only screen and (min-width: $breakpoint-sm) {
+    width: 80%;
+  }
+
+  @media only screen and (min-width: $breakpoint-lg) {
+    width: 75%;
+    max-width: 60rem;
+  }
+}
+
+.row {
+  position: relative;
+  width: 100%;
+
+  &::after {
+    content: "";
+    display: table;
+    clear: both;
+  }
+}
+
+.row [class^="col"] {
+  float: left;
+  margin: $spacing-sm 2%;
+  min-height: 0.125rem;
+}
+
+// Mobile-first: all columns are full width
+.col-1,
+.col-2,
+.col-3,
+.col-4,
+.col-5,
+.col-6,
+.col-7,
+.col-8,
+.col-9,
+.col-10,
+.col-11,
+.col-12 {
+  width: 96%;
+}
+
+// Small column variants (always apply)
+.col-1-sm { width: 4.33%; }
+.col-2-sm { width: 12.66%; }
+.col-3-sm { width: 21%; }
+.col-4-sm { width: 29.33%; }
+.col-5-sm { width: 37.66%; }
+.col-6-sm { width: 46%; }
+.col-7-sm { width: 54.33%; }
+.col-8-sm { width: 62.66%; }
+.col-9-sm { width: 71%; }
+.col-10-sm { width: 79.33%; }
+.col-11-sm { width: 87.66%; }
+.col-12-sm { width: 96%; }
+
+.hidden-sm {
+  display: none;
+}
+
+// Desktop columns
+@media only screen and (min-width: $breakpoint-md) {
+  .col-1 { width: 4.33%; }
+  .col-2 { width: 12.66%; }
+  .col-3 { width: 21%; }
+  .col-4 { width: 29.33%; }
+  .col-5 { width: 37.66%; }
+  .col-6 { width: 46%; }
+  .col-7 { width: 54.33%; }
+  .col-8 { width: 62.66%; }
+  .col-9 { width: 71%; }
+  .col-10 { width: 79.33%; }
+  .col-11 { width: 87.66%; }
+  .col-12 { width: 96%; }
+
+  .hidden-sm {
+    display: block;
+  }
+}
+
+// -----------------------------------------------------------------------------
+// Header actions wrapper (applies to all themes)
+// -----------------------------------------------------------------------------
+
+.header-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: $spacing-sm;
+}
+
+// -----------------------------------------------------------------------------
+// Profile Section (applies to all themes)
+// -----------------------------------------------------------------------------
+
+@media only screen and (min-width: $breakpoint-md) {
+  .profile-row {
+    display: flex;
+    align-items: center;
+  }
+
+  .profile-row .col-6 {
+    float: none;
+  }
+
+  .profile-left {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+  }
+}
+
+// -----------------------------------------------------------------------------
+// Non-Hacker Theme Header/Footer Overrides
+// -----------------------------------------------------------------------------
+
+html:not(.theme-hacker) {
+  header {
+    background: var(--bg-secondary);
+    border-bottom: 1px solid var(--border);
+    padding: $spacing-xl 0;
+    margin: 0 0 40px 0;
+
+    .container {
+      padding-bottom: 0;
+    }
+
+    h1 {
+      color: var(--text-primary);
+      text-shadow: none;
+      font-family: $font-sans;
+      font-weight: 700;
+      margin: 0 0 $spacing-sm;
+      font-size: 30px;
+      line-height: 1.5;
+
+      &:before {
+        content: none;
+      }
+
+      a {
+        color: var(--text-primary);
+        text-decoration: none;
+        text-shadow: none;
+
+        &:hover {
+          color: var(--accent);
+        }
+      }
+    }
+
+    h2 {
+      color: var(--text-secondary);
+      font-size: $font-size-base;
+      font-weight: normal;
+      margin: 0 0 $spacing-lg;
+      font-family: $font-sans;
+      text-shadow: none;
+    }
+  }
+
+  // Button overrides for non-hacker themes
+  .btn {
+    background: transparent;
+    border: 1px solid var(--border);
+    border-radius: $radius-md;
+    color: var(--text-secondary);
+    box-shadow: none;
+    text-shadow: none;
+    font-family: $font-sans;
+
+    &:hover {
+      border-color: var(--accent);
+      color: var(--accent);
+      background: transparent;
+    }
+  }
+
+  // Footer
+  .site-footer {
+    background: var(--bg-secondary);
+    border-top: 1px solid var(--border);
+
+    h3 {
+      color: var(--accent);
+    }
+
+    a {
+      color: var(--text-primary);
+      text-shadow: none;
+
+      &:hover {
+        color: var(--accent);
+      }
+    }
+  }
+
+  .footer-bottom {
+    border-top: 1px solid var(--border);
+
+    p {
+      color: var(--text-tertiary);
+    }
+  }
+}

--- a/_sass/site/_switcher.scss
+++ b/_sass/site/_switcher.scss
@@ -1,0 +1,75 @@
+// =============================================================================
+// THEME SWITCHER STYLES
+// Dropdown component for switching between themes (in footer)
+// =============================================================================
+
+.theme-switcher {
+  display: inline-flex;
+  align-items: center;
+  gap: $spacing-sm;
+  margin-top: $spacing-md;
+}
+
+.theme-switcher-label {
+  font-size: $font-size-sm;
+  color: #888;
+}
+
+html:not(.theme-hacker) .theme-switcher-label {
+  color: var(--text-secondary);
+}
+
+#theme-select {
+  appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  background: #1a1a1a;
+  border: 1px solid #333;
+  border-radius: $radius-md;
+  color: #ccc;
+  padding: $spacing-sm $spacing-xl $spacing-sm $spacing-md;
+  font-size: $font-size-sm;
+  font-family: inherit;
+  cursor: pointer;
+  transition: border-color $transition-fast, background-color $transition-fast;
+
+  // Custom dropdown arrow
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath fill='%23888' d='M6 8L2 4h8z'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right $spacing-sm center;
+
+  &:hover {
+    border-color: #b5e853;
+  }
+
+  &:focus {
+    outline: none;
+    border-color: #b5e853;
+  }
+
+  option {
+    background: #1a1a1a;
+    color: #ccc;
+    padding: $spacing-sm;
+  }
+}
+
+html:not(.theme-hacker) #theme-select {
+  background-color: var(--bg-secondary);
+  border-color: var(--border);
+  color: var(--text-primary);
+
+  &:hover {
+    border-color: var(--accent);
+  }
+
+  &:focus {
+    border-color: var(--accent);
+    box-shadow: 0 0 0 2px var(--shadow);
+  }
+
+  option {
+    background: var(--bg-secondary);
+    color: var(--text-primary);
+  }
+}

--- a/_sass/site/_themes.scss
+++ b/_sass/site/_themes.scss
@@ -1,0 +1,35 @@
+// =============================================================================
+// SITE THEMES
+// Generates theme classes from $themes map using CSS custom properties
+// =============================================================================
+
+// -----------------------------------------------------------------------------
+// Theme Application Mixin
+// Outputs CSS custom properties for a given theme
+// -----------------------------------------------------------------------------
+
+@mixin apply-theme($theme) {
+  --bg-primary: #{map-get($theme, bg-primary)};
+  --bg-secondary: #{map-get($theme, bg-secondary)};
+  --bg-tertiary: #{map-get($theme, bg-tertiary)};
+  --text-primary: #{map-get($theme, text-primary)};
+  --text-secondary: #{map-get($theme, text-secondary)};
+  --text-tertiary: #{map-get($theme, text-tertiary)};
+  --accent: #{map-get($theme, accent)};
+  --accent-hover: #{map-get($theme, accent-hover)};
+  --accent-alt: #{map-get($theme, accent-alt)};
+  --border: #{map-get($theme, border)};
+  --border-light: #{map-get($theme, border-light)};
+  --shadow: #{map-get($theme, shadow)};
+}
+
+// -----------------------------------------------------------------------------
+// Generate Theme Classes
+// Creates .theme-{name} classes on html element
+// -----------------------------------------------------------------------------
+
+@each $name, $theme in $themes {
+  .theme-#{$name} {
+    @include apply-theme($theme);
+  }
+}

--- a/_sass/site/_variables.scss
+++ b/_sass/site/_variables.scss
@@ -1,0 +1,134 @@
+// =============================================================================
+// SITE VARIABLES
+// Theme definitions and shared design tokens
+// =============================================================================
+
+// -----------------------------------------------------------------------------
+// Theme Color Maps
+// Each theme defines CSS custom properties for runtime switching
+// Tokens: bg-primary, bg-secondary, bg-tertiary, text-primary, text-secondary,
+//         text-tertiary, accent, accent-hover, accent-alt, border, border-light, shadow
+// -----------------------------------------------------------------------------
+
+$themes: (
+  hacker: (
+    bg-primary: #151515,
+    bg-secondary: #1a1a1a,
+    bg-tertiary: #222222,
+    text-primary: #ccc,
+    text-secondary: #888,
+    text-tertiary: #666,
+    accent: #b5e853,
+    accent-hover: #9ccc3d,
+    accent-alt: #7cb833,
+    border: #333,
+    border-light: #444,
+    shadow: rgba(0, 0, 0, 0.3)
+  ),
+  neon: (
+    bg-primary: #0a0a0f,
+    bg-secondary: #12121a,
+    bg-tertiary: #1a1a25,
+    text-primary: #e0e0e0,
+    text-secondary: #a0a0a0,
+    text-tertiary: #707070,
+    accent: #00ff88,
+    accent-hover: #00cc6a,
+    accent-alt: #00ffcc,
+    border: #2a2a35,
+    border-light: #3a3a45,
+    shadow: rgba(0, 255, 136, 0.1)
+  ),
+  minimal: (
+    bg-primary: #ffffff,
+    bg-secondary: #f8fafc,
+    bg-tertiary: #f1f5f9,
+    text-primary: #111111,
+    text-secondary: #4b5563,
+    text-tertiary: #9ca3af,
+    accent: #2563eb,
+    accent-hover: #1d4ed8,
+    accent-alt: #3b82f6,
+    border: #e5e7eb,
+    border-light: #f3f4f6,
+    shadow: rgba(0, 0, 0, 0.1)
+  ),
+  twilight: (
+    bg-primary: #1e1b2e,
+    bg-secondary: #262339,
+    bg-tertiary: #2e2a44,
+    text-primary: #e8e4f0,
+    text-secondary: #a8a4b8,
+    text-tertiary: #787488,
+    accent: #f78166,
+    accent-hover: #e5704f,
+    accent-alt: #ff9f7f,
+    border: #3d3952,
+    border-light: #4d4962,
+    shadow: rgba(247, 129, 102, 0.1)
+  ),
+  paper: (
+    bg-primary: #fdfbf7,
+    bg-secondary: #f5f3ef,
+    bg-tertiary: #edebe7,
+    text-primary: #2d2a24,
+    text-secondary: #5c5850,
+    text-tertiary: #8a8680,
+    accent: #b44a2d,
+    accent-hover: #963d24,
+    accent-alt: #d45a3a,
+    border: #d4d0c8,
+    border-light: #e4e0d8,
+    shadow: rgba(0, 0, 0, 0.08)
+  )
+);
+
+// -----------------------------------------------------------------------------
+// Typography
+// -----------------------------------------------------------------------------
+
+$font-sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+$font-mono: 'Courier New', Courier, monospace;
+
+$font-size-xs: 0.75rem;
+$font-size-sm: 0.85rem;
+$font-size-base: 1rem;
+$font-size-lg: 1.2rem;
+$font-size-xl: 1.5rem;
+$font-size-2xl: 2rem;
+
+// -----------------------------------------------------------------------------
+// Spacing Scale
+// -----------------------------------------------------------------------------
+
+$spacing-xs: 0.25rem;
+$spacing-sm: 0.5rem;
+$spacing-md: 1rem;
+$spacing-lg: 1.5rem;
+$spacing-xl: 2rem;
+$spacing-2xl: 3rem;
+
+// -----------------------------------------------------------------------------
+// Border Radius
+// -----------------------------------------------------------------------------
+
+$radius-sm: 0.25rem;
+$radius-md: 0.375rem;
+$radius-lg: 0.5rem;
+$radius-full: 50%;
+
+// -----------------------------------------------------------------------------
+// Breakpoints
+// -----------------------------------------------------------------------------
+
+$breakpoint-sm: 33.75em;  // 540px
+$breakpoint-md: 45em;     // 720px
+$breakpoint-lg: 60em;     // 960px
+
+// -----------------------------------------------------------------------------
+// Transitions
+// -----------------------------------------------------------------------------
+
+$transition-fast: 0.15s ease-in-out;
+$transition-base: 0.2s ease-in-out;
+$transition-slow: 0.3s ease-in-out;

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -1,0 +1,25 @@
+---
+---
+
+// =============================================================================
+// MAIN STYLESHEET
+// Entry point that imports all partials
+// =============================================================================
+
+// Variables must come first (defines $themes, spacing, typography, etc.)
+@import "site/variables";
+
+// Theme classes (generates .theme-* classes with CSS custom properties)
+@import "site/themes";
+
+// Base styles (reset, typography, links)
+@import "site/base";
+
+// Layout (grid, header, footer)
+@import "site/layout";
+
+// Components (publications, CV, contributions, etc.)
+@import "site/components";
+
+// Theme switcher dropdown
+@import "site/switcher";

--- a/assets/js/theme-switcher.js
+++ b/assets/js/theme-switcher.js
@@ -1,0 +1,92 @@
+/**
+ * Theme Switcher
+ * Handles theme persistence and switching
+ */
+
+(function() {
+  'use strict';
+
+  var STORAGE_KEY = 'site-theme';
+  var DEFAULT_THEME = 'hacker';
+  var VALID_THEMES = ['hacker', 'neon', 'minimal', 'twilight', 'paper'];
+
+  /**
+   * Get the saved theme from localStorage
+   * @returns {string} The saved theme or default
+   */
+  function getSavedTheme() {
+    try {
+      var saved = localStorage.getItem(STORAGE_KEY);
+      if (saved && VALID_THEMES.indexOf(saved) !== -1) {
+        return saved;
+      }
+    } catch (e) {
+      // localStorage not available
+    }
+    return DEFAULT_THEME;
+  }
+
+  /**
+   * Save theme to localStorage
+   * @param {string} theme - Theme name to save
+   */
+  function saveTheme(theme) {
+    try {
+      localStorage.setItem(STORAGE_KEY, theme);
+    } catch (e) {
+      // localStorage not available
+    }
+  }
+
+  /**
+   * Apply theme to document
+   * @param {string} theme - Theme name to apply
+   */
+  function applyTheme(theme) {
+    // Remove all theme classes
+    VALID_THEMES.forEach(function(t) {
+      document.documentElement.classList.remove('theme-' + t);
+    });
+    // Add new theme class
+    document.documentElement.classList.add('theme-' + theme);
+  }
+
+  /**
+   * Set theme and persist
+   * @param {string} theme - Theme name
+   */
+  function setTheme(theme) {
+    if (VALID_THEMES.indexOf(theme) === -1) {
+      theme = DEFAULT_THEME;
+    }
+    applyTheme(theme);
+    saveTheme(theme);
+  }
+
+  /**
+   * Initialize theme switcher
+   */
+  function init() {
+    var select = document.getElementById('theme-select');
+    if (!select) return;
+
+    // Set select value to current theme
+    var currentTheme = getSavedTheme();
+    select.value = currentTheme;
+
+    // Listen for changes
+    select.addEventListener('change', function(e) {
+      setTheme(e.target.value);
+    });
+  }
+
+  // Expose setTheme globally for inline handlers
+  window.setTheme = setTheme;
+
+  // Initialize on DOM ready
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();


### PR DESCRIPTION
Add a theme switcher dropdown in the footer allowing users to switch between 5 themes: Hacker (default), Neon, Minimal, Twilight, and Paper.

- Create modular SCSS architecture in _sass/site/
- Use CSS custom properties for runtime theme switching
- Preserve original Hacker theme design exactly
- Persist theme selection in localStorage
- Prevent flash of unstyled content with inline script