### PR TITLE
feat: reorder homepage sections, experience first

### DIFF
--- a/index.md
+++ b/index.md
@@ -61,6 +61,10 @@
   </div>
 </div>
 
+## Experience
+
+{% include cv-jobs.html %}
+
 ## Research publications
 
 {% include publications.html %}
@@ -72,10 +76,6 @@
 ## Open source software contributions
 
 {% include opensource.html %}
-
-## Experience
-
-{% include cv-jobs.html %}
 
 ## Education
 


### PR DESCRIPTION
## Summary
- Move Experience section right after the profile, before publications
- New order: Experience, Research publications, Public talks, Open source, Education

## Test plan
- [ ] Verify homepage renders correctly with new section order