### PR TITLE
feat: add profile summary section to CV page

### DIFF
--- a/_data/jobs.yml
+++ b/_data/jobs.yml
@@ -114,10 +114,11 @@
       start: 2020
       end: 2023
   description: |
-    Nomadic Labs are Tezos blockchain experts. Working on the core development,
-    evolution and adoption of the Tezos protocol in BENELUX.
-    Working in the cryptography team, focusing on the development on zero-knowledge
-    protocols, mainly the project Epoxy, a validity rollup for the Tezos protocol.
+    Nomadic Labs are Tezos blockchain experts. Working on the core
+    development, evolution and adoption of the Tezos protocol in
+    BENELUX. Contributed to the protocol itself and worked in the
+    cryptography team, focusing on zero-knowledge protocols, mainly
+    Epoxy, a validity rollup for the Tezos protocol.
   links:
     - label: Cryptography team website
       url: https://research-development.nomadic-labs.com/files/cryptography.html

--- a/_sass/site/_components.scss
+++ b/_sass/site/_components.scss
@@ -155,6 +155,17 @@
   font-weight: 500;
 }
 
+.cv-note {
+  font-size: 0.9em;
+  font-style: italic;
+  opacity: 0.8;
+}
+
+.cv-summary {
+  font-style: italic;
+  line-height: 1.6;
+}
+
 .cv-dates {
   font-size: $font-size-sm;
   color: var(--text-secondary);

--- a/cv.html
+++ b/cv.html
@@ -12,8 +12,32 @@ permalink: /cv/
     <span><a href="https://dannywillems.github.io">dannywillems.github.io</a></span>
     <span><a href="https://github.com/dannywillems">github.com/dannywillems</a></span>
     <span><a href="https://linkedin.com/in/bedannywillems">LinkedIn</a></span>
+    <span><a href="https://twitter.com/dwillems42">Twitter</a></span>
   </div>
+  <p class="cv-note">For the most up-to-date overview of my work, see my GitHub, LinkedIn, and Twitter profiles.</p>
 </header>
+
+<section class="cv-section">
+  <p class="cv-summary">
+    Mathematician and engineer with 10+ years of experience in
+    cryptography research, infrastructure, and production systems.
+    First engineer at B2C2, one of the earliest institutional crypto
+    liquidity providers (acquired by SBI Holdings in 2020), leading
+    the real-time accounting systems, blockchain node infrastructure
+    for real-time transaction monitoring, and exchange interfaces for
+    PnL detection. Co-founder of LeakIX, an attack surface management
+    platform serving 100+ clients and multiple national CERTs.
+    Cryptography researcher and engineer at o1Labs (Mina Protocol),
+    and led a team to reimplement the node in Rust. Contributed to
+    core
+    cryptographic infrastructure and the protocol itself at Nomadic
+    Labs (Tezos), and
+    co-authored peer-reviewed publications on arithmetization-oriented
+    hash functions and PlonK optimizations. Currently running BaDaaS,
+    an independent mathematics research boutique, building tools to
+    formally verify the world's cryptographic knowledge.
+  </p>
+</section>
 
 <section class="cv-section">
   <h2>Professional Experience</h2>


### PR DESCRIPTION
## Summary
- Add a profile summary paragraph at the top of the CV page
- Covers: 10+ years experience, B2C2 (first engineer), LeakIX (co-founder, 100+ clients, national CERTs), o1Labs (team lead), Nomadic Labs, publications, BaDaaS

## Test plan
- [ ] Verify summary renders correctly on /cv/