### PR TITLE
chore: merge develop into master

### DIFF
--- a/_data/jobs.yml
+++ b/_data/jobs.yml
@@ -114,10 +114,11 @@
       start: 2020
       end: 2023
   description: |
-    Nomadic Labs are Tezos blockchain experts. Working on the core development,
-    evolution and adoption of the Tezos protocol in BENELUX.
-    Working in the cryptography team, focusing on the development on zero-knowledge
-    protocols, mainly the project Epoxy, a validity rollup for the Tezos protocol.
+    Nomadic Labs are Tezos blockchain experts. Working on the core
+    development, evolution and adoption of the Tezos protocol in
+    BENELUX. Contributed to the protocol itself and worked in the
+    cryptography team, focusing on zero-knowledge protocols, mainly
+    Epoxy, a validity rollup for the Tezos protocol.
   links:
     - label: Cryptography team website
       url: https://research-development.nomadic-labs.com/files/cryptography.html

--- a/_data/jobs.yml
+++ b/_data/jobs.yml
@@ -24,11 +24,10 @@
       convert, validate, and extract structured mathematical
       knowledge from cryptographic research papers, building toward
       the first formally verified knowledge base of the field.
-    - **[cryptography.academy](https://cryptography.academy)**: a
-      collaborative platform to formally verify the world's
-      cryptographic knowledge, transforming scattered research PDFs
-      into a queryable, cross-referenced, machine-checkable
-      knowledge graph.
+    - **[cryptography.academy](https://cryptography.academy)**: the
+      web frontend for the Papyrus pipeline, presenting all
+      extracted and verified cryptographic knowledge in a unified,
+      searchable interface.
     - **[LeakIX](https://leakix.net)**: co-founded attack surface
       management platform combining a search engine indexing public
       information and an open reporting platform for vulnerability

--- a/_data/jobs.yml
+++ b/_data/jobs.yml
@@ -20,17 +20,19 @@
 
     Current projects:
 
-    - **Papyrus**: a pipeline to convert, validate, and extract
-      structured mathematical knowledge from cryptographic research
-      papers, building toward the first formally verified knowledge
-      base of the field.
-    - **cryptography.academy**: a collaborative platform to formally
-      verify the world's cryptographic knowledge, transforming
-      scattered research PDFs into a queryable, cross-referenced,
-      machine-checkable knowledge graph.
-    - **LeakIX**: co-founded attack surface management platform
-      combining a search engine indexing public information and an
-      open reporting platform for vulnerability disclosure.
+    - **[Papyrus](https://papyrus.badaas.eu)**: a pipeline to
+      convert, validate, and extract structured mathematical
+      knowledge from cryptographic research papers, building toward
+      the first formally verified knowledge base of the field.
+    - **[cryptography.academy](https://cryptography.academy)**: a
+      collaborative platform to formally verify the world's
+      cryptographic knowledge, transforming scattered research PDFs
+      into a queryable, cross-referenced, machine-checkable
+      knowledge graph.
+    - **[LeakIX](https://leakix.net)**: co-founded attack surface
+      management platform combining a search engine indexing public
+      information and an open reporting platform for vulnerability
+      disclosure.
   links:
     - label: BaDaaS
       url: https://badaas.be

--- a/_data/jobs.yml
+++ b/_data/jobs.yml
@@ -52,8 +52,27 @@
       start: April 2023
       end: May 2025
   description: |
-    o1Labs is a global and remote company that incubated the Mina Protocol.
-    Our team operates on the cutting edge of Web3 and zero-knowledge-proofs.
+    o1Labs incubated the Mina Protocol, a layer-1 blockchain using
+    zero-knowledge proofs for succinctness.
+
+    As **Head of Cryptography**, oversaw the cryptography architecture
+    across an engineering team of 15-20 people, and led a team of up
+    to 5 engineers on the full rewrite of the Mina node from OCaml
+    to Rust.
+
+    As **Senior Cryptography Engineer**, contributed to
+    [o1VM](https://github.com/o1-labs/proof-systems/tree/master/o1vm),
+    a zkVM for MIPS built as a team effort. Implemented the RISC-V
+    interpreter, focused on the folding aspect, and designed and
+    started building
+    [Arrabbiata](https://github.com/o1-labs/proof-systems/tree/master/arrabbiata),
+    a folding scheme for arbitrary custom gates and degrees.
+    Contributed to
+    [Pickles](https://github.com/MinaProtocol/mina/tree/compatible/src/lib/crypto/pickles),
+    the recursion layer used in Mina based on Halo2 (Plonk-ish
+    implementation of Halo), and to the
+    [proof-systems](https://github.com/o1-labs/proof-systems)
+    library (Kimchi, custom gates, lookups).
   links:
     - label: o1Labs
       url: https://o1labs.org
@@ -61,6 +80,10 @@
       url: https://github.com/o1-labs/mina-rust
     - label: Proof Systems
       url: https://github.com/o1-labs/proof-systems
+    - label: o1VM
+      url: https://github.com/o1-labs/proof-systems/tree/master/o1vm
+    - label: Arrabbiata
+      url: https://github.com/o1-labs/proof-systems/tree/master/arrabbiata
     - label: OCaml Node
       url: https://github.com/MinaProtocol/mina
 

--- a/_sass/site/_components.scss
+++ b/_sass/site/_components.scss
@@ -155,6 +155,17 @@
   font-weight: 500;
 }
 
+.cv-note {
+  font-size: 0.9em;
+  font-style: italic;
+  opacity: 0.8;
+}
+
+.cv-summary {
+  font-style: italic;
+  line-height: 1.6;
+}
+
 .cv-dates {
   font-size: $font-size-sm;
   color: var(--text-secondary);

--- a/cv.html
+++ b/cv.html
@@ -12,8 +12,32 @@ permalink: /cv/
     <span><a href="https://dannywillems.github.io">dannywillems.github.io</a></span>
     <span><a href="https://github.com/dannywillems">github.com/dannywillems</a></span>
     <span><a href="https://linkedin.com/in/bedannywillems">LinkedIn</a></span>
+    <span><a href="https://twitter.com/dwillems42">Twitter</a></span>
   </div>
+  <p class="cv-note">For the most up-to-date overview of my work, see my GitHub, LinkedIn, and Twitter profiles.</p>
 </header>
+
+<section class="cv-section">
+  <p class="cv-summary">
+    Mathematician and engineer with 10+ years of experience in
+    cryptography research, infrastructure, and production systems.
+    First engineer at B2C2, one of the earliest institutional crypto
+    liquidity providers (acquired by SBI Holdings in 2020), leading
+    the real-time accounting systems, blockchain node infrastructure
+    for real-time transaction monitoring, and exchange interfaces for
+    PnL detection. Co-founder of LeakIX, an attack surface management
+    platform serving 100+ clients and multiple national CERTs.
+    Cryptography researcher and engineer at o1Labs (Mina Protocol),
+    and led a team to reimplement the node in Rust. Contributed to
+    core
+    cryptographic infrastructure and the protocol itself at Nomadic
+    Labs (Tezos), and
+    co-authored peer-reviewed publications on arithmetization-oriented
+    hash functions and PlonK optimizations. Currently running BaDaaS,
+    an independent mathematics research boutique, building tools to
+    formally verify the world's cryptographic knowledge.
+  </p>
+</section>
 
 <section class="cv-section">
   <h2>Professional Experience</h2>

--- a/cv.html
+++ b/cv.html
@@ -33,6 +33,13 @@ permalink: /cv/
       {{ job.description | markdownify }}
     </div>
     {% endif %}
+    {% if job.links %}
+    <div class="cv-pub-venue">
+      {% for link in job.links %}
+        <a href="{{ link.url }}">{{ link.label }}</a>{% unless forloop.last %} | {% endunless %}
+      {% endfor %}
+    </div>
+    {% endif %}
   </div>
   {% endfor %}
 </section>

--- a/index.md
+++ b/index.md
@@ -61,6 +61,10 @@
   </div>
 </div>
 
+## Experience
+
+{% include cv-jobs.html %}
+
 ## Research publications
 
 {% include publications.html %}
@@ -72,10 +76,6 @@
 ## Open source software contributions
 
 {% include opensource.html %}
-
-## Experience
-
-{% include cv-jobs.html %}
 
 ## Education
 


### PR DESCRIPTION
## Summary
- Add profile summary section to CV page
- Reorder homepage sections (experience first)
- Expand o1Labs description with concrete achievements
- Clarify cryptography.academy as Papyrus frontend
- Render job links on CV page
- Add inline links for BaDaaS project names
- Update Nomadic Labs description

## Test plan
- [ ] Verify CV page and homepage render correctly