### PR TITLE
feat: update homepage intro, currently section, and LeakIX description

### DIFF
--- a/_data/jobs.yml
+++ b/_data/jobs.yml
@@ -91,15 +91,20 @@
       start: 2021
       end: Present
   description: |
-    LeakIX is the first platform combining a search engine indexing public
-    information by scanning Internet and an open reporting platform linked to the results.
-    We intent to provide a preemptive solution by trusting individual researchers
-    and security companies on the most sensible data we index by delivering a clear
-    report on the incidents, we also help to identify what information has/could be
-    affected and how to resolve the issue.
-    Our first goal is one of prevention, all the voluntary reports are free
-    and no sales attempts are made on LeakIX's side.
-    We ban sales attempt that would take advantage of the issue to sell shady security services.
+    Co-founded with Gregory Boddin. LeakIX is an attack surface
+    management platform combining a search engine that indexes
+    public information by scanning the Internet and an open
+    reporting platform for vulnerability disclosure. Serving 100+
+    clients and multiple national CERTs.
+
+    Our goal is prevention: we intend to provide a preemptive
+    solution by trusting individual researchers and security
+    companies on the most sensitive data we index. We deliver clear
+    incident reports, help identify what information has or could be
+    affected, and explain how to resolve the issue. All voluntary
+    reports are free and no sales attempts are made on LeakIX's
+    side. We ban sales attempts that take advantage of incidents to
+    sell shady security services.
   links:
     - label: Website
       url: https://leakix.net

--- a/index.md
+++ b/index.md
@@ -6,7 +6,7 @@
     <p class="center">
       Currently:
       <br />
-      Independent Cryptography Engineer & Researcher
+      Independent Researcher & Engineer @ <a href="https://badaas.be">BaDaaS</a>
       <br />
       Co-founder @ <a href="https://leakix.net">LeakIX</a>
     </p>
@@ -37,27 +37,37 @@
     </div>
   </div>
   <div class="col-6">
-    Hi! I am Danny Willems. I am a mathematician with multiple interests, mostly
-    related to computer sciences and theoretical physics.
+    Hi! I am Danny Willems. I am a mathematician with multiple
+    interests, mostly related to computer sciences and theoretical
+    physics.
     <br />
-    I spend most of my time <b>trying</b> to provide a better Internet for
-    everyone.
-    With this mission in mind, I co-founded <a
-    href="https://leakix.net">LeakIX</a> in 2021 with Gregory Boddin and we
-    aim to be the Internet red team. I am also an independent cryptography
-    engineer and researcher. Previously, I was Head of Cryptography and led the
-    Rust Node team at <a href="https://o1labs.org">o1Labs</a>, working on
-    zero-knowledge cryptography for the Mina Protocol.
+    I run <a href="https://badaas.be">BaDaaS</a>, a mathematics
+    research boutique focused on cryptography and formal
+    verification. I am currently building
+    <a href="https://papyrus.badaas.eu">Papyrus</a> and
+    <a href="https://cryptography.academy">cryptography.academy</a>,
+    tools to formally verify the world's cryptographic knowledge.
+    I also co-founded <a href="https://leakix.net">LeakIX</a> in
+    2021 with Gregory Boddin, an attack surface management platform
+    serving 100+ clients and multiple national CERTs.
     <br />
-    My current interest in cryptography is incrementally verifiable computation. I
-    have also been interested in arithmetization-oriented cryptographic primitives.
-    On my free-time I read about cybersecurity, low-level code optimizations, formal
-    verification and mathematics applied to physics. I also enjoy doing recreational
-    mathematics.
+    Previously, I was Head of Cryptography at
+    <a href="https://o1labs.org">o1Labs</a> and led a team to
+    reimplement the Mina Protocol node in Rust. Before that, I
+    worked as a cryptography engineer at
+    <a href="https://nomadic-labs.com">Nomadic Labs</a> on the
+    Tezos protocol.
     <br />
-    Nowadays, I like getting my hands dirty coding in C, OCaml, Rust and read
-    assembly code. Constantly requiring to be in an intellectually stimulating
-    environment.
+    My current interest in cryptography is incrementally verifiable
+    computation. I have also been interested in
+    arithmetization-oriented cryptographic primitives. On my
+    free-time I read about cybersecurity, low-level code
+    optimizations, formal verification and mathematics applied to
+    physics. I also enjoy doing recreational mathematics.
+    <br />
+    Nowadays, I like getting my hands dirty coding in C, OCaml,
+    Rust and read assembly code. Constantly requiring to be in an
+    intellectually stimulating environment.
   </div>
 </div>
 


### PR DESCRIPTION
## Summary
- Homepage "Currently" section now mentions BaDaaS
- Homepage intro text updated: mentions BaDaaS, Papyrus, cryptography.academy, LeakIX metrics, o1Labs Rust rewrite, Nomadic Labs
- LeakIX job description polished: fixed grammar (intent->intend, sensible->sensitive, sales attempt->sales attempts), added co-founder credit, metrics (100+ clients, national CERTs)

## Test plan
- [ ] Verify homepage renders correctly
- [ ] Verify LeakIX entry renders correctly on /cv/