### PR TITLE
feat: expand Nomadic Labs description and add PhD entry

### DIFF
--- a/_data/education.yml
+++ b/_data/education.yml
@@ -1,5 +1,15 @@
 # Education history
 
+- institution: Institut Polytechnique de Paris (IPP)
+  url: https://www.ip-paris.fr/en
+  degree: PhD Candidate in Cryptography (not completed)
+  start: 2022
+  end: 2023
+  description: |
+    Under the direction of
+    [Benjamin Smith](https://www.lix.polytechnique.fr/~smith/)
+    (INRIA, Ecole Polytechnique). Discontinued to join o1Labs.
+
 - institution: University of Mons
   url: https://math.umons.ac.be/en/
   degree: Master's Degree Mathematics and Computer Sciences

--- a/_data/jobs.yml
+++ b/_data/jobs.yml
@@ -116,16 +116,41 @@
       start: 2020
       end: 2023
   description: |
-    Nomadic Labs are Tezos blockchain experts. Working on the core
-    development, evolution and adoption of the Tezos protocol in
-    BENELUX. Contributed to the protocol itself and worked in the
-    cryptography team, focusing on zero-knowledge protocols, mainly
-    Epoxy, a validity rollup for the Tezos protocol.
+    Nomadic Labs are Tezos blockchain experts. Cryptography engineer
+    in the cryptography team, contributing to the Tezos protocol and
+    its zero-knowledge research and development.
+
+    - Co-authored the
+      [Anemoi/Jive](https://eprint.iacr.org/2022/840) paper on
+      arithmetization-oriented hash functions for PlonK-based
+      systems. Focused on implementation and CPU optimizations.
+    - Co-authored the
+      [PlonK optimizations](https://eprint.iacr.org/2022/462)
+      paper. Focused on implementation.
+    - Built and maintained the
+      [ocaml-bls12-381](https://gitlab.com/dannywillems/ocaml-bls12-381)
+      ecosystem: pairing operations, BLS signatures, and hash
+      functions over BLS12-381.
+    - Contributed to
+      [Plompiler](https://opam.ocaml.org/packages/tezos-plompiler),
+      a monadic DSL for building aPlonK circuits.
+    - Worked on Epoxy, a validity rollup for the Tezos protocol.
+    - Contributed directly to the Tezos protocol
+      ([Octez](https://gitlab.com/tezos/tezos/)).
+
+    Also enrolled at Institut Polytechnique de Paris (IPP) for a
+    PhD in cryptography under the direction of
+    [Benjamin Smith](https://www.lix.polytechnique.fr/~smith/)
+    (INRIA, Ecole Polytechnique). Discontinued to join o1Labs.
   links:
     - label: Cryptography team website
       url: https://research-development.nomadic-labs.com/files/cryptography.html
     - label: Nomadic Labs
       url: https://nomadic-labs.com
+    - label: Anemoi/Jive paper
+      url: https://eprint.iacr.org/2022/840
+    - label: ocaml-bls12-381
+      url: https://gitlab.com/dannywillems/ocaml-bls12-381
 
 - employer: B2C2
   url: https://www.b2c2.com


### PR DESCRIPTION
## Summary
- Expand Nomadic Labs description: Anemoi/Jive (implementation/CPU optimizations), ocaml-bls12-381 ecosystem, Plompiler, Epoxy, Octez contributions
- Add PhD note in Nomadic Labs description (IPP, Benjamin Smith at INRIA/Ecole Polytechnique, discontinued to join o1Labs)
- Add PhD entry in education section (2022-2023)
- Link to Benjamin Smith's profile
- Add links to Anemoi paper and ocaml-bls12-381

## Test plan
- [ ] Verify Nomadic Labs entry renders correctly on /cv/
- [ ] Verify education section renders correctly
- [ ] Verify all links work