### PR TITLE
feat: CV improvements batch

### DIFF
--- a/_data/jobs.yml
+++ b/_data/jobs.yml
@@ -182,16 +182,18 @@
       url: https://b2c2.com
 
 - employer: Be Sport
+  early: true
   positions:
     - title: Intern
       start: July 2016
       end: November 2016
   description: |
-    Social network around sports. The platform is built using OCaml and the Ocsigen
-    technology. During the internship, I was responsible to improve the framework
-    Ocsigen Start, which consists of a template to bootstrap a complete standard
-    applications require users management, displaying tips, sending notifications
-    to the users.
+    Social network around sports. The platform is built using
+    OCaml and the Ocsigen technology. During the internship, I
+    was responsible to improve the framework Ocsigen Start, which
+    consists of a template to bootstrap a complete standard
+    application requiring user management, displaying tips, and
+    sending notifications to the users.
   links:
     - label: Be Sport
       url: https://besport.com
@@ -201,13 +203,15 @@
       url: https://github.com/ocsigen/ocsigen-start
 
 - employer: Selfpharma
+  early: true
   positions:
     - title: Cordova Mobile Application Engineer
       start: August 2015
       end: February 2016
   description: |
-    Online pharmacy shop based in Brussels, Belgium, built using Prestashop.
-    Leading the iOS and Android mobile applications development, written in Cordova.
+    Online pharmacy shop based in Brussels, Belgium, built using
+    Prestashop. Leading the iOS and Android mobile applications
+    development, written in Cordova.
   links:
     - label: Website
       url: https://selfpharma.com
@@ -217,10 +221,11 @@
       url: https://apps.apple.com/be/app/selfpharma/id1007247480
 
 - employer: INRIA Paris
+  early: true
   positions:
     - title: Research Intern - Gallium Team
       start: February 2016
       end: June 2016
   description: |
-    Research internship in the Gallium team, focusing on module systems in functional
-    programming languages.
+    Research internship in the Gallium team, focusing on module
+    systems in functional programming languages.

--- a/_includes/cv-jobs.html
+++ b/_includes/cv-jobs.html
@@ -1,5 +1,45 @@
 <div class="cv-jobs">
+{% assign early_started = false %}
 {% for job in site.data.jobs %}
+  {% if job.early %}
+    {% unless early_started %}
+      {% assign early_started = true %}
+  <details class="cv-early-experience">
+    <summary>Earlier experience (2015-2016)</summary>
+    {% endunless %}
+    <div class="cv-job">
+      <div class="cv-employer">
+        {% if job.url %}
+          <a href="{{ job.url }}">{{ job.employer }}</a>
+        {% else %}
+          {{ job.employer }}
+        {% endif %}
+      </div>
+
+      <div class="cv-positions">
+        {% for position in job.positions %}
+          <div class="cv-position{% if job.positions.size > 1 %} cv-position-multi{% endif %}">
+            <span class="cv-title">{{ position.title }}</span>
+            <span class="cv-dates">{{ position.start }} - {{ position.end }}</span>
+          </div>
+        {% endfor %}
+      </div>
+
+      {% if job.description %}
+        <div class="cv-description">
+          {{ job.description | markdownify }}
+        </div>
+      {% endif %}
+
+      {% if job.links %}
+        <div class="cv-links">
+          {% for link in job.links %}
+            <a class="publication-link" href="{{ link.url }}">{{ link.label }}</a>
+          {% endfor %}
+        </div>
+      {% endif %}
+    </div>
+  {% else %}
   <div class="cv-job">
     <div class="cv-employer">
       {% if job.url %}
@@ -32,5 +72,9 @@
       </div>
     {% endif %}
   </div>
+  {% endif %}
 {% endfor %}
+{% if early_started %}
+  </details>
+{% endif %}
 </div>

--- a/cv.html
+++ b/cv.html
@@ -13,6 +13,7 @@ permalink: /cv/
     <span><a href="https://github.com/dannywillems">github.com/dannywillems</a></span>
     <span><a href="https://linkedin.com/in/bedannywillems">LinkedIn</a></span>
     <span><a href="https://twitter.com/dwillems42">Twitter</a></span>
+    <span><a href="https://www.iacr.org/cryptodb/data/author.php?authorkey=12524">IACR</a></span>
   </div>
   <p class="cv-note">For the most up-to-date overview of my work, see my GitHub, LinkedIn, and Twitter profiles.</p>
 </header>
@@ -33,7 +34,9 @@ permalink: /cv/
     cryptographic infrastructure and the protocol itself at Nomadic
     Labs (Tezos), and
     co-authored peer-reviewed publications on arithmetization-oriented
-    hash functions and PlonK optimizations. Currently running BaDaaS,
+    hash functions and PlonK optimizations. Research interests include
+    SNARK-friendly primitives based on elliptic curves and
+    incrementally verifiable computation. Currently running BaDaaS,
     an independent mathematics research boutique, building tools to
     formally verify the world's cryptographic knowledge.
   </p>
@@ -41,7 +44,38 @@ permalink: /cv/
 
 <section class="cv-section">
   <h2>Professional Experience</h2>
+  {% assign early_started = false %}
   {% for job in site.data.jobs %}
+  {% if job.early %}
+    {% unless early_started %}
+      {% assign early_started = true %}
+  <details class="cv-early-experience">
+    <summary>Earlier experience (2015-2016)</summary>
+    {% endunless %}
+    <div class="cv-entry">
+      <div class="cv-entry-employer">
+        {% if job.url %}<a href="{{ job.url }}">{{ job.employer }}</a>{% else %}{{ job.employer }}{% endif %}
+      </div>
+      {% for position in job.positions %}
+      <div class="cv-entry-header">
+        <span class="cv-entry-title">{{ position.title }}</span>
+        <span class="cv-entry-dates">{{ position.start }} - {{ position.end }}</span>
+      </div>
+      {% endfor %}
+      {% if job.description %}
+      <div class="cv-entry-description">
+        {{ job.description | markdownify }}
+      </div>
+      {% endif %}
+      {% if job.links %}
+      <div class="cv-pub-venue">
+        {% for link in job.links %}
+          <a href="{{ link.url }}">{{ link.label }}</a>{% unless forloop.last %} | {% endunless %}
+        {% endfor %}
+      </div>
+      {% endif %}
+    </div>
+  {% else %}
   <div class="cv-entry">
     <div class="cv-entry-employer">
       {% if job.url %}<a href="{{ job.url }}">{{ job.employer }}</a>{% else %}{{ job.employer }}{% endif %}
@@ -65,7 +99,11 @@ permalink: /cv/
     </div>
     {% endif %}
   </div>
+  {% endif %}
   {% endfor %}
+  {% if early_started %}
+  </details>
+  {% endif %}
 </section>
 
 <section class="cv-section">
@@ -126,7 +164,7 @@ permalink: /cv/
 
 <section class="cv-section">
   <h2>Notable Open Source Contributions</h2>
-  {% for project in site.data.opensource limit:5 %}
+  {% for project in site.data.opensource %}
   <div class="cv-pub">
     <div class="cv-pub-title">{{ project.title }}</div>
     {% if project.links %}

--- a/index.md
+++ b/index.md
@@ -37,13 +37,12 @@
     </div>
   </div>
   <div class="col-6">
-    Hi! I am Danny Willems. I am a mathematician with multiple
-    interests, mostly related to computer sciences and theoretical
-    physics.
+    Hi! I am Danny Willems. I am a mathematician and engineer
+    working at the intersection of cryptography, formal
+    verification, and distributed systems.
     <br />
     I run <a href="https://badaas.be">BaDaaS</a>, a mathematics
-    research boutique focused on cryptography and formal
-    verification. I am currently building
+    research boutique. I am currently building
     <a href="https://papyrus.badaas.eu">Papyrus</a> and
     <a href="https://cryptography.academy">cryptography.academy</a>,
     tools to formally verify the world's cryptographic knowledge.
@@ -58,12 +57,11 @@
     <a href="https://nomadic-labs.com">Nomadic Labs</a> on the
     Tezos protocol.
     <br />
-    My current interest in cryptography is incrementally verifiable
-    computation. I have also been interested in
-    arithmetization-oriented cryptographic primitives. On my
-    free-time I read about cybersecurity, low-level code
-    optimizations, formal verification and mathematics applied to
-    physics. I also enjoy doing recreational mathematics.
+    My current research interests include incrementally verifiable
+    computation and SNARK-friendly primitives based on elliptic
+    curves. On my free-time I read about cybersecurity, low-level
+    code optimizations, formal verification and mathematics applied
+    to physics. I also enjoy doing recreational mathematics.
     <br />
     Nowadays, I like getting my hands dirty coding in C, OCaml,
     Rust and read assembly code. Constantly requiring to be in an


### PR DESCRIPTION
## Summary
- **10**: Remove open source limit (was 5, now shows all 13 projects)
- **16**: Add research interests (SNARK-friendly primitives, IVC) to CV summary
- **17**: Update homepage intro (cleaner framing, research interests)
- **18**: Add IACR CryptoDB link to CV contact section
- **20**: Collapse early experience (Be Sport, Selfpharma, INRIA) into a collapsible details section on both CV page and homepage

## Test plan
- [ ] Verify all open source projects render on /cv/
- [ ] Verify collapsible early experience works on /cv/ and homepage
- [ ] Verify IACR link works
- [ ] Verify homepage intro reads well