### PR TITLE
feat: add BaDaaS employer entry

### DIFF
--- a/_data/jobs.yml
+++ b/_data/jobs.yml
@@ -13,6 +13,21 @@
     proof systems to post-quantum cryptography, from machine-checked proofs
     in Lean 4 to open-source infrastructure, we work across the full stack
     of mathematical engineering.
+
+    Current projects:
+
+    - **[Papyrus](https://papyrus.badaas.eu)**: a pipeline to
+      convert, validate, and extract structured mathematical
+      knowledge from cryptographic research papers, building toward
+      the first formally verified knowledge base of the field.
+    - **[cryptography.academy](https://cryptography.academy)**: the
+      web frontend for the Papyrus pipeline, presenting all
+      extracted and verified cryptographic knowledge in a unified,
+      searchable interface.
+    - **[LeakIX](https://leakix.net)**: co-founded attack surface
+      management platform combining a search engine indexing public
+      information and an open reporting platform for vulnerability
+      disclosure.
   links:
     - label: BaDaaS
       url: https://badaas.be

--- a/_data/jobs.yml
+++ b/_data/jobs.yml
@@ -8,27 +8,11 @@
       start: March 2026
       end: Present
   description: |
-    BaDaaS is a Belgium-based mathematics research boutique founded
-    in 2020, bridging abstract mathematics and concrete applications.
-    Currently specialized in cryptography, formal verification, and
-    distributed systems. Consulting, research, and engineering for
-    protocol design, cryptographic library development, and security
-    auditing.
-
-    Current projects:
-
-    - **[Papyrus](https://papyrus.badaas.eu)**: a pipeline to
-      convert, validate, and extract structured mathematical
-      knowledge from cryptographic research papers, building toward
-      the first formally verified knowledge base of the field.
-    - **[cryptography.academy](https://cryptography.academy)**: the
-      web frontend for the Papyrus pipeline, presenting all
-      extracted and verified cryptographic knowledge in a unified,
-      searchable interface.
-    - **[LeakIX](https://leakix.net)**: co-founded attack surface
-      management platform combining a search engine indexing public
-      information and an open reporting platform for vulnerability
-      disclosure.
+    BaDaaS is a mathematics research boutique. We specialise in applied
+    cryptography, formal verification, and AI tooling. From zero-knowledge
+    proof systems to post-quantum cryptography, from machine-checked proofs
+    in Lean 4 to open-source infrastructure, we work across the full stack
+    of mathematical engineering.
   links:
     - label: BaDaaS
       url: https://badaas.be

--- a/_data/jobs.yml
+++ b/_data/jobs.yml
@@ -8,11 +8,13 @@
       start: March 2026
       end: Present
   description: |
-    BaDaaS is a mathematics research boutique. We specialise in applied
-    cryptography, formal verification, and AI tooling. From zero-knowledge
-    proof systems to post-quantum cryptography, from machine-checked proofs
-    in Lean 4 to open-source infrastructure, we work across the full stack
-    of mathematical engineering.
+    BaDaaS is a Belgium-based mathematics research boutique founded
+    in 2020, bridging abstract mathematics and concrete applications.
+    Currently specialized in cryptography, formal verification,
+    post-quantum cryptography, cryptanalysis of arithmetisation
+    oriented hash functions, and distributed systems. Consulting,
+    research, and engineering for protocol design, cryptographic
+    library development, and security auditing.
 
     Current projects:
 


### PR DESCRIPTION
## Summary

- Replace the "Independent" employer entry with BaDaaS in `_data/jobs.yml`
- Description reflects the current website copy: mathematics research boutique specialising in applied cryptography, formal verification, and AI tooling

## Test plan

- [ ] Verify the BaDaaS entry renders correctly on the homepage Experience section
- [ ] Verify the CV page at /cv/ shows BaDaaS with the updated description