### PR TITLE
feat: add ZODL role and update bio for new full-time position

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # dannywillems.github.io
 
 Personal website of Danny Willems. Mathematician, cryptography researcher and
-engineer. Open to opportunities. Founder of [BaDaaS](https://badaas.be)
-(personal research). Part-time involved at [LeakIX](https://leakix.net).
+engineer. Principal Cryptography Engineer at [ZODL](https://zodl.com) (Zcash
+Open Development Labs). Part-time involved in [LeakIX](https://leakix.net) and
+[BaDaaS](https://badaas.be) (personal research).
 
 Live at: https://dannywillems.github.io
 

--- a/_data/jobs.yml
+++ b/_data/jobs.yml
@@ -33,6 +33,18 @@
     - label: LeakIX
       url: https://leakix.net
 
+- employer: ZODL (Zcash Open Development Labs)
+  url: https://zodl.com
+  positions:
+    - title: Principal Cryptography Engineer
+      start: May 2026
+      end: Present
+  description: |
+    Zcash Open Development Labs, working on the Zcash protocol.
+  links:
+    - label: ZODL
+      url: https://zodl.com
+
 - employer: o1Labs
   url: https://o1labs.org
   positions:

--- a/cv.html
+++ b/cv.html
@@ -24,7 +24,9 @@ permalink: /cv/
     Mathematician, cryptography engineer & researcher with 10+
     years of experience in cryptography research, infrastructure,
     and production systems.
-    <strong>Currently open to opportunities.</strong>
+    <strong>Currently Principal Cryptography Engineer at
+    <a href="https://zodl.com" target="_blank" rel="noopener noreferrer">ZODL</a>
+    (Zcash Open Development Labs).</strong>
   </p>
 </section>
 

--- a/index.md
+++ b/index.md
@@ -8,11 +8,9 @@ use_math: true
         <img class="portrait" src="{{ '/assets/me.jpg' | relative_url }}" alt="Danny Willems portrait" loading="lazy" />
     </div>
     <p class="center">
-      <strong>Open to opportunities</strong>
+      <strong>Principal Cryptography Engineer @ <a href="https://zodl.com" target="_blank" rel="noopener noreferrer">ZODL</a></strong>
       <br />
-      Independent Researcher @ <a href="https://badaas.be" target="_blank" rel="noopener noreferrer">BaDaaS</a> (personal research)
-      <br />
-      Part-time involved @ <a href="https://leakix.net" target="_blank" rel="noopener noreferrer">LeakIX</a>
+      Part-time involved in <a href="https://leakix.net" target="_blank" rel="noopener noreferrer">LeakIX</a> & <a href="https://badaas.be" target="_blank" rel="noopener noreferrer">BaDaaS</a>
     </p>
     <div class="center">
        <a href="https://twitter.com/dwillems42" class="logo-link" target="_blank" rel="noopener noreferrer">
@@ -44,7 +42,9 @@ use_math: true
     Hi! I am Danny Willems. I am a mathematician, cryptography
     engineer and researcher working at the intersection of
     cryptography, formal verification, and distributed systems.
-    I am currently <a href="mailto:danny@badaas.be"><strong>looking for new opportunities</strong></a>.
+    I am currently Principal Cryptography Engineer at
+    <a href="https://zodl.com" target="_blank" rel="noopener noreferrer">ZODL</a>
+    (Zcash Open Development Labs), working on the Zcash protocol.
     <br />
     On the side, I run <a href="https://badaas.be" target="_blank" rel="noopener noreferrer">BaDaaS</a>,
     a personal mathematics research boutique where I build


### PR DESCRIPTION
## Summary

- Add ZODL (Zcash Open Development Labs) as a new full-time role in
  `_data/jobs.yml`, Principal Cryptography Engineer, starting May 2026.
- Remove "open to opportunities" mentions across `index.md`, `cv.html`,
  and `README.md` (now full-time at ZODL).
- Update the homepage line under the portrait to a single line:
  "Part-time involved in LeakIX & BaDaaS".

## Test plan

- [ ] Verify homepage renders the updated header and bio paragraph.
- [ ] Verify CV page shows the new ZODL entry at the top of past/current
      full-time positions and the updated summary line.
- [ ] Verify README is rendered correctly on GitHub.