### PR TITLE
fix: quote Emacs post titles to repair broken YAML front matter

### DIFF
--- a/_posts/2026-05-28-emacs-security-hardening.md
+++ b/_posts/2026-05-28-emacs-security-hardening.md
@@ -1,5 +1,5 @@
 ---
-title: Hardening a hand-rolled Emacs config: five findings and their fixes
+title: "Hardening a hand-rolled Emacs config: five findings and their fixes"
 author: Danny Willems
 date: 2026-05-28 00:00:00 +0000
 layout: post

--- a/_posts/2026-05-28-emacs-setup-story.md
+++ b/_posts/2026-05-28-emacs-setup-story.md
@@ -1,5 +1,5 @@
 ---
-title: From Spacemacs to a small hand-rolled Emacs: why and what is in it
+title: "From Spacemacs to a small hand-rolled Emacs: why and what is in it"
 author: Danny Willems
 date: 2026-05-28 00:00:00 +0000
 layout: post


### PR DESCRIPTION
## Problem

The blog index showed two **title-less** entries at the top, both dated **May 30, 2026**, instead of the two Emacs posts that should appear under **May 28**:

- `2026-05-28-emacs-setup-story.md`
- `2026-05-28-emacs-security-hardening.md`

## Root cause

Both `title:` values contained an unquoted **colon-space**:

- `From Spacemacs to a small hand-rolled Emacs: why and what is in it`
- `Hardening a hand-rolled Emacs config: five findings and their fixes`

In YAML, `: ` is the key/value separator, so an unquoted scalar cannot contain it. Psych raises:

```
Psych::SyntaxError: mapping values are not allowed in this context
```

Jekyll then fails to parse the front matter, so the **title renders blank** and the **date falls back to the build date** (May 30), which is why both posts surfaced as untitled "May 30" entries.

## Fix

Wrap both titles in double quotes. Verified each now parses:

- title => `"From Spacemacs to a small hand-rolled Emacs: why and what is in it"`, date => `2026-05-28`
- title => `"Hardening a hand-rolled Emacs config: five findings and their fixes"`, date => `2026-05-28`

No content changes; prettier passes.