### PR TITLE
chore: pin prettier so local formatting matches CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,9 +17,10 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: '20'
+          cache: 'npm'
 
-      - name: Install Prettier
-        run: npm install -g prettier
+      - name: Install pinned tooling
+        run: npm ci
 
       - name: Check formatting
         run: make check-format

--- a/Makefile
+++ b/Makefile
@@ -46,21 +46,25 @@ lint: ## Lint markdown files
 		echo "markdownlint not installed. Install with: npm install -g markdownlint-cli"; \
 	fi
 
+.PHONY: install-node
+install-node: ## Install pinned Node tooling (prettier) from package-lock.json
+	npm ci
+
 .PHONY: format
-format: ## Format files with prettier
-	@if command -v prettier >/dev/null 2>&1; then \
-		prettier --write "**/*.css" "*.md" "_posts/*.md"; \
+format: ## Format files with the pinned prettier
+	@if [ -x node_modules/.bin/prettier ]; then \
+		node_modules/.bin/prettier --write "**/*.css" "*.md" "_posts/*.md"; \
 	else \
-		echo "prettier not installed. Install with: npm install -g prettier"; \
+		echo "prettier not installed. Run: make install-node (or npm ci)"; \
 		exit 1; \
 	fi
 
 .PHONY: check-format
-check-format: ## Check formatting with prettier
-	@if command -v prettier >/dev/null 2>&1; then \
-		prettier --check "**/*.css" "*.md" "_posts/*.md"; \
+check-format: ## Check formatting with the pinned prettier
+	@if [ -x node_modules/.bin/prettier ]; then \
+		node_modules/.bin/prettier --check "**/*.css" "*.md" "_posts/*.md"; \
 	else \
-		echo "prettier not installed. Install with: npm install -g prettier"; \
+		echo "prettier not installed. Run: make install-node (or npm ci)"; \
 		exit 1; \
 	fi
 

--- a/index.md
+++ b/index.md
@@ -119,7 +119,8 @@ use_math: true
 - [A Cypherpunk's Manifesto](https://www.activism.net/cypherpunk/manifesto.html) -
   Eric Hughes
 - [How To Become A Hacker](https://www.catb.org/~esr/faqs/hacker-howto.html) -
-Eric Steven Raymond
+  Eric Steven Raymond
+
 <!-- ## Recent scientific readings -->
 
 <!-- Here will come my notes on scientific papers/article I read. Mostly to keep a -->

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,31 @@
+{
+  "name": "dannywillems-github-io",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "dannywillems-github-io",
+      "version": "1.0.0",
+      "devDependencies": {
+        "prettier": "3.9.5"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.9.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.5.tgz",
+      "integrity": "sha512-/FVl766LpUfB5vXgCYOYa0MeV/441Ia99AeICQIQFTY/Nw0roZwULcXpku5i1/m5kt/baz+s4Zogspd839HSMg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "dannywillems-github-io",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Tooling for the personal website. Prettier is pinned here so local formatting matches CI exactly.",
+  "scripts": {
+    "format": "prettier --write \"**/*.css\" \"*.md\" \"_posts/*.md\"",
+    "check-format": "prettier --check \"**/*.css\" \"*.md\" \"_posts/*.md\""
+  },
+  "devDependencies": {
+    "prettier": "3.9.5"
+  }
+}


### PR DESCRIPTION
## Problem

The `format` CI job runs `npm install -g prettier` (unpinned), so CI currently uses prettier 3.9.5 while a local `make check-format` uses whatever version is installed. 3.9.5 reformats `index.md` where 3.8.x did not, so the format check is red on `develop` regardless of the change under review.

## Fix

- Pin prettier to `3.9.5` in a new `package.json` + `package-lock.json`.
- Run prettier from `node_modules` in the `format` / `check-format` Makefile targets (add `make install-node` = `npm ci`).
- Switch the CI format job from `npm install -g prettier` to `npm ci` (with npm cache).
- Reformat `index.md` under the pinned version (formatting only, no content change).

`node_modules/` is already gitignored and covered by Jekyll's default exclude, so the site build is unaffected.

Merging this unblocks the format check for all PRs (including #568, the web-auth post).